### PR TITLE
Auto edit peer id and private key

### DIFF
--- a/config_scripts/install_scripts.sh
+++ b/config_scripts/install_scripts.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Installing scripts..."
+wget https://raw.githubusercontent.com/3box/ceramic-infra-scripts/main/ipfs-config-identity.sh
+echo "Done installing scripts"

--- a/container_daemon
+++ b/container_daemon
@@ -49,6 +49,13 @@ else
   # Unset the swarm key file variable
   unset IPFS_SWARM_KEY_FILE
 
+  # Set up the identity key and id, if provided
+
+  if [ ! -z "$IPFS_PRIVATE_KEY" ]; then
+    echo "Copying private key and peer id into config from environment..."
+    ./config_scripts/ipfs-config-identity.sh $repo/config $IPFS_PEER_ID $IPFS_PRIVATE_KEY || exit 1
+  fi
+
   if [ $IPFS_ENABLE_S3 == true ] ; then
     echo "Configuring S3 datastore plugin..."
 

--- a/container_daemon
+++ b/container_daemon
@@ -63,7 +63,7 @@ fi
 
 ipfs config Addresses.API "/ip4/0.0.0.0/tcp/$IPFS_API_PORT"
 ipfs config Addresses.Gateway "/ip4/0.0.0.0/tcp/$IPFS_GATEWAY_PORT"
-ipfs config --json Addresses.Swarm "[\"/ip4/0.0.0.0/tcp/$IPFS_SWARM_TCP_PORT/ws\", \"/ip4/0.0.0.0/tcp/$IPFS_SWARM_WS_PORT/ws\"]"
+ipfs config --json Addresses.Swarm "[\"/ip4/0.0.0.0/tcp/$IPFS_SWARM_TCP_PORT\", \"/ip4/0.0.0.0/tcp/$IPFS_SWARM_WS_PORT/ws\"]"
 # if [ ! "IPFS_ANNOUNCE_ADDRESS_LIST" -eq "" ]; then
 #   ipfs config --json Addresses.Announce "[\"$IPFS_ANNOUNCE_ADDRESS_LIST\"]"
 # fi


### PR DESCRIPTION
This PR allows the container daemon to use environment variables to configure the private key and peer id used by IPFS.

After **initializing** the repo,
if the `$IPFS_PRIVATE_KEY` environment variable is non-empty,
the `$IPFS_PATH/config` file will be modified to set `Identity.PrivKey` to `$IPFS_PRIVATE_KEY` and set `Identity.PeerID` to `$IPFS_PEER_ID`.

If the repo is already initialized when the container comes up, no changes to `Identity` will be made.

### Notes
- jq is installed to edit the config file. This is required because go-ipfs "[cannot show or change private key through API](https://docs.ipfs.io/how-to/use-existing-private-key/#go-ipfs)".
- This PR turns auto-migrations off
- This PR resets swarm addresses to `tcp/...` and `tcp/.../ws`