### PR TITLE
feat: new ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ on:
 
 env:
   # Dagger
-  DAGGER_CI: cue.mod/pkg/github.com/3box/pipelinetools/ci/main.cue
+  DAGGER_CI: cue.mod/pkg/github.com/3box/pipeline-tools/ci/main.cue
+  DAGGER_VERSION: "0.2.15"
+  #PIPELINE_TOOLS_VER: "0.1.1-alpha"
   COMPONENT: "ipfs"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -20,27 +22,19 @@ env:
 
 jobs:
   push:
-    name: Build and push
+    name: Test and push image
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Dump github context
-        run: echo "$GITHUB_CONTEXT"
-        shell: bash
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       -
         name: Checkout code
         uses: actions/checkout@v3
       -
-        # Pull the latest pipelinetools.
-        # TODO: Once the code is stable, use a tagged version.
         name: Run CI pipeline
         uses: dagger/dagger-for-github@v3
         with:
-          version: "v0.2.13"
+          version: ${{ env.DAGGER_VERSION }}
           cmds: |
             project init
             project update
-            project update github.com/3box/pipelinetools@develop
+            project update "github.com/3box/pipeline-tools@develop
             do build -p ${{ env.DAGGER_CI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   # Dagger
   DAGGER_CI: cue.mod/pkg/github.com/3box/pipeline-tools/ci/main.cue
   DAGGER_VERSION: "0.2.15"
-  #PIPELINE_TOOLS_VER: "0.1.1-alpha"
+  PIPELINE_TOOLS_VER: "0.1.0"
   COMPONENT: "ipfs"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
@@ -36,5 +36,5 @@ jobs:
           cmds: |
             project init
             project update
-            project update "github.com/3box/pipeline-tools@develop
+            project update "github.com/3box/pipeline-tools@v${{ env.PIPELINE_TOOLS_VER }}
             do build -p ${{ env.DAGGER_CI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: Test and publish Docker images
+
+on:
+  push:
+    branches: [ develop, release-candidate, main ]
+  pull_request: # pull requests
+  workflow_dispatch: # manually triggered
+
+env:
+  # Dagger
+  DAGGER_LOG_FORMAT: plain
+  DAGGER_LOG_LEVEL: info
+  DAGGER_CACHE_BASE: ipfs-ci
+  DAGGER_CI: cue.mod/pkg/github.com/3box/pipelinetools/ci/main.cue
+  REPO_TYPE: "ipfs"
+  # Secrets
+  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+jobs:
+  push:
+    name: Build and push
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Dump github context
+        run: echo "$GITHUB_CONTEXT"
+        shell: bash
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+      -
+        name: Checkout code
+        uses: actions/checkout@v3
+      -
+        name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v1
+      -
+        name: Set up cache for mainline branches
+        run: |
+          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{ env.DAGGER_CACHE_BASE }}-main" >> $GITHUB_ENV
+          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-main" >> $GITHUB_ENV
+      -
+        name: Set up cache for for pull requests
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{ env.DAGGER_CACHE_BASE }}-${{ github.event.number }}" >> $GITHUB_ENV
+          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-main type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-${{ github.event.number }}" >> $GITHUB_ENV
+      -
+        # Pull the latest pipelinetools.
+        # TODO: Once the code is stable, use a tagged version.
+        name: Run CI pipeline
+        uses: dagger/dagger-for-github@v3
+        with:
+          version: "v0.2.12"
+          cmds: |
+            project init
+            project update
+            project update github.com/3box/pipelinetools@develop
+            do build -p ${{ env.DAGGER_CI }}
+      -
+        name: Print Buildkitd Logs
+        if: ${{ failure() }}
+        run: docker logs dagger-buildkitd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,5 @@ jobs:
           cmds: |
             project init
             project update
-            project update "github.com/3box/pipeline-tools@v${{ env.PIPELINE_TOOLS_VER }}
+            project update "github.com/3box/pipeline-tools@v${{ env.PIPELINE_TOOLS_VER }}"
             do build -p ${{ env.DAGGER_CI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,8 @@ on:
 
 env:
   # Dagger
-  DAGGER_LOG_FORMAT: plain
-  DAGGER_LOG_LEVEL: info
-  DAGGER_CACHE_BASE: ipfs-ci
   DAGGER_CI: cue.mod/pkg/github.com/3box/pipelinetools/ci/main.cue
-  REPO_TYPE: "ipfs"
+  COMPONENT: "ipfs"
   # Secrets
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -36,32 +33,14 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v3
       -
-        name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v1
-      -
-        name: Set up cache for mainline branches
-        run: |
-          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{ env.DAGGER_CACHE_BASE }}-main" >> $GITHUB_ENV
-          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-main" >> $GITHUB_ENV
-      -
-        name: Set up cache for for pull requests
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{ env.DAGGER_CACHE_BASE }}-${{ github.event.number }}" >> $GITHUB_ENV
-          echo "DAGGER_CACHE_FROM=type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-main type=gha,scope=${{ env.DAGGER_CACHE_BASE }}-${{ github.event.number }}" >> $GITHUB_ENV
-      -
         # Pull the latest pipelinetools.
         # TODO: Once the code is stable, use a tagged version.
         name: Run CI pipeline
         uses: dagger/dagger-for-github@v3
         with:
-          version: "v0.2.12"
+          version: "v0.2.13"
           cmds: |
             project init
             project update
             project update github.com/3box/pipelinetools@develop
             do build -p ${{ env.DAGGER_CI }}
-      -
-        name: Print Buildkitd Logs
-        if: ${{ failure() }}
-        run: docker logs dagger-buildkitd

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+cue.mod/


### PR DESCRIPTION
This PR implements a new CI pipeline using [Dagger](https://dagger.io/).

This allows the various Ceramic component pipelines to be written entirely agnostically of the pipeline service (e.g. GitHub Workflows).

Dagger is still a little rough around the edges so some of the syntax is non-intuitive. However, as they improve their DX, we'll be able to clean this code up as well.

I've decided to keep the actual pipeline [Dagger plan](https://docs.dagger.io/1202/plan) in a [separate repository](https://github.com/3box/pipelinetools) that can be used from other Ceramic repos instead of scattering the code across the repos.

I have intentionally not deprecated the old pipeline (CircleCI, building an image, posting to Lambda, etc.) until the new one can run correctly end-to-end in parallel.

Tasks accomplished with this PR:

- [x] Builds the code
- [x] Builds the Docker image
- [x] Start the Docker image and runs a `curl` request to the `healthcheck` endpoint.
- [x] Pushes the image to DockerHub and ECR
- [x] Queues an event to the job queue