### PR TITLE
fix: re-enable swarm relay client

### DIFF
--- a/container_daemon
+++ b/container_daemon
@@ -80,6 +80,6 @@ ipfs config --json Addresses.Swarm "[\"/ip4/0.0.0.0/tcp/$IPFS_SWARM_TCP_PORT\", 
 # fi
 ipfs config --json Pubsub.Enabled true
 ipfs config algorithm "rsa"
-ipfs config --json Swarm.RelayClient.Enabled false
+ipfs config --json Swarm.RelayClient.Enabled true
 
 exec ipfs "$@"


### PR DESCRIPTION
Need to re-enable it explicitly instead of just removing the line since our config is persistent.