### PR TITLE
fix: remove explicit rsa algorithm from config

### DIFF
--- a/container_daemon
+++ b/container_daemon
@@ -80,7 +80,6 @@ ipfs config --json Addresses.Swarm "[\"/ip4/0.0.0.0/tcp/$IPFS_SWARM_TCP_PORT\", 
 # fi
 ipfs config --json Pubsub.Enabled true
 ipfs config Pubsub.SeenMessagesTTL 10m
-ipfs config algorithm "rsa"
 ipfs config --json Swarm.RelayClient.Enabled true
 
 BOOTSTRAP_PEERS='[


### PR DESCRIPTION
Default is ed25519, which is more efficient.