### PR TITLE
feat: use container-init.d mechanism to initialize config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,9 +108,6 @@ EXPOSE $IPFS_SWARM_TCP_PORT/udp
 # Daemon API; must not be exposed publicly but to client services under you control
 ENV IPFS_API_PORT 5001
 EXPOSE $IPFS_API_PORT
-# Web Gateway; can be exposed publicly with a proxy, e.g. as https://ipfs.example.org
-ENV IPFS_GATEWAY_PORT 8080
-EXPOSE $IPFS_GATEWAY_PORT
 # Swarm Websockets; must be exposed publicly when the node is listening using the websocket transport (/ipX/.../tcp/8081/ws).
 ENV IPFS_SWARM_WS_PORT 8081
 EXPOSE $IPFS_SWARM_WS_PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,10 +68,7 @@ RUN set -eux; \
   && chmod +x jq \
   && cd /tmp \
   && wget -q -O curl https://github.com/moparisthebest/static-curl/releases/download/$CURL_VERSION/curl-amd64 \
-  && chmod +x curl \
-  && cd /config_scripts \
-  && ./install_scripts.sh \
-  && chmod -R +x /config_scripts
+  && chmod +x curl
 
 # Now comes the actual target image, which aims to be as small as possible.
 FROM busybox:1.31.1-glibc

--- a/config_scripts/install_scripts.sh
+++ b/config_scripts/install_scripts.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-echo "Installing scripts..."
-wget https://raw.githubusercontent.com/3box/ceramic-infra-scripts/main/ipfs-config-identity.sh
-echo "Done installing scripts"

--- a/config_scripts/ipfs-config-identity.sh
+++ b/config_scripts/ipfs-config-identity.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+FILE=$1
+PEER=$2
+PRIV=$3
+TEMP=$(mktemp)
+
+jq --arg PRIV "$PRIV" '.Identity.PrivKey = $PRIV' $FILE > "$TEMP" && mv "$TEMP" $FILE || exit 1
+jq --arg PEER "$PEER" '.Identity.PeerID = $PEER' $FILE > "$TEMP" && mv "$TEMP" $FILE || exit 1
+cat $FILE | jq '.Identity'
+

--- a/container-init.d/000-ceramic.sh
+++ b/container-init.d/000-ceramic.sh
@@ -1,59 +1,14 @@
 #!/bin/sh
 set -e
-user=ipfs
+
 repo="$IPFS_PATH"
-
-if [ `id -u` -eq 0 ]; then
-  echo "Changing user to $user"
-  # ensure folder is writable
-  su-exec "$user" test -w "$repo" || chown -R -- "$user" "$repo"
-  # restart script with new privileges
-  exec su-exec "$user" "$0" "$@"
-fi
-
-# 2nd invocation with regular user
-ipfs version
 
 if [ -e "$repo/config" ]; then
   echo "Found IPFS fs-repo at $repo"
 else
-  case "$IPFS_PROFILE" in
-    "") INIT_ARGS="" ;;
-    *) INIT_ARGS="--profile=$IPFS_PROFILE " ;;
-  esac
-  ipfs init "$INIT_ARGS--algorithm=rsa"
-
-  # Set up the swarm key, if provided
-
-  SWARM_KEY_FILE="$repo/swarm.key"
-  SWARM_KEY_PERM=0400
-
-  # Create a swarm key from a given environment variable
-  if [ ! -z "$IPFS_SWARM_KEY" ] ; then
-    echo "Copying swarm key from variable..."
-    echo -e "$IPFS_SWARM_KEY" >"$SWARM_KEY_FILE" || exit 1
-    chmod $SWARM_KEY_PERM "$SWARM_KEY_FILE"
-  fi
-
-  # Unset the swarm key variable
-  unset IPFS_SWARM_KEY
-
-  # Check during initialization if a swarm key was provided and
-  # copy it to the ipfs directory with the right permissions
-  # WARNING: This will replace the swarm key if it exists
-  if [ ! -z "$IPFS_SWARM_KEY_FILE" ] ; then
-    echo "Copying swarm key from file..."
-    install -m $SWARM_KEY_PERM "$IPFS_SWARM_KEY_FILE" "$SWARM_KEY_FILE" || exit 1
-  fi
-
-  # Unset the swarm key file variable
-  unset IPFS_SWARM_KEY_FILE
-
-  # Set up the identity key and id, if provided
-
   if [ ! -z "$IPFS_PRIVATE_KEY" ]; then
     echo "Copying private key and peer id into config from environment..."
-    ./config_scripts/ipfs-config-identity.sh $repo/config $IPFS_PEER_ID $IPFS_PRIVATE_KEY || exit 1
+    /config_scripts/ipfs-config-identity.sh $repo/config $IPFS_PEER_ID $IPFS_PRIVATE_KEY || exit 1
   fi
 
   if [ $IPFS_ENABLE_S3 == true ] ; then
@@ -65,7 +20,6 @@ else
     echo "Updating datastore_spec..."
     echo "$(/config_scripts/datastore_spec.s3.sh)" > $IPFS_PATH/datastore_spec
   fi
-
 fi
 
 # Explicitly run the migration before any configuration because, for some reason, trying to run the migration after the
@@ -75,9 +29,6 @@ ipfs repo migrate
 ipfs config Addresses.API "/ip4/0.0.0.0/tcp/$IPFS_API_PORT"
 ipfs config Addresses.Gateway "/ip4/0.0.0.0/tcp/$IPFS_GATEWAY_PORT"
 ipfs config --json Addresses.Swarm "[\"/ip4/0.0.0.0/tcp/$IPFS_SWARM_TCP_PORT\", \"/ip4/0.0.0.0/tcp/$IPFS_SWARM_WS_PORT/ws\"]"
-# if [ ! "IPFS_ANNOUNCE_ADDRESS_LIST" -eq "" ]; then
-#   ipfs config --json Addresses.Announce "[\"$IPFS_ANNOUNCE_ADDRESS_LIST\"]"
-# fi
 ipfs config --json Pubsub.Enabled true
 ipfs config Pubsub.SeenMessagesTTL 10m
 ipfs config --json Swarm.RelayClient.Enabled false
@@ -90,5 +41,3 @@ BOOTSTRAP_PEERS='[
   {"ID": "QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd", "Addrs": ["/dns4/go-ipfs-ceramic-private-cas-clay-external.3boxlabs.com/tcp/4011/ws/p2p/QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd"]}
 ]'
 ipfs config --json Peering.Peers "${BOOTSTRAP_PEERS}"
-
-exec ipfs "$@"

--- a/container-init.d/000-ceramic.sh
+++ b/container-init.d/000-ceramic.sh
@@ -27,7 +27,8 @@ fi
 ipfs repo migrate
 
 ipfs config Addresses.API "/ip4/0.0.0.0/tcp/$IPFS_API_PORT"
-ipfs config Addresses.Gateway "/ip4/0.0.0.0/tcp/$IPFS_GATEWAY_PORT"
+# Explicitly disable the gateway
+ipfs config --json Addresses.Gateway '[]'
 ipfs config --json Addresses.Swarm "[\"/ip4/0.0.0.0/tcp/$IPFS_SWARM_TCP_PORT\", \"/ip4/0.0.0.0/tcp/$IPFS_SWARM_WS_PORT/ws\"]"
 ipfs config --json Pubsub.Enabled true
 ipfs config Pubsub.SeenMessagesTTL 10m


### PR DESCRIPTION
The upstream image from Kubo now has a mechanism to run an init script before the daemon starts. Instead of replacing the start_ipfs script with our own we now use the upstream script and then add in our own init script. This enable further downstream consumers of this image to further customize the configuration.

## How Has This Been Tested?

Ran the test suite and manual testing using this image inside keramik.
