### PR TITLE
feat: add gitcoin peer id to bootstrap peers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,6 @@ WORKDIR /clone
 
 RUN git clone --depth 1 --branch v0.19.1-validator https://github.com/ceramicnetwork/kubo kubo
 
-# Append the short sha to the Kubo version string
-RUN cd kubo && \
-    SHA=$(echo "${2:-$(git rev-parse HEAD)}" | cut -c 1-7) && \
-    sed -i "/CurrentVersionNumber/s/\"$/-$SHA\"/" version.go
-
 # Note: when updating the go minor version here, also update the go-channel in snap/snapcraft.yml
 FROM golang:1.19.1-buster as builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /clone
 
 RUN git clone --depth 1 --branch v0.19.1-validator https://github.com/ceramicnetwork/kubo kubo
 
+# Append the short sha to the Kubo version string
+RUN SHA=$(echo "${2:-$(git rev-parse HEAD)}" | cut -c 1-7) && sed -i "/CurrentVersionNumber/s/\"$/-$SHA\"/" version.go
+
 # Note: when updating the go minor version here, also update the go-channel in snap/snapcraft.yml
 FROM golang:1.19.1-buster as builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /clone
 RUN git clone --depth 1 --branch v0.19.1-validator https://github.com/ceramicnetwork/kubo kubo
 
 # Append the short sha to the Kubo version string
-RUN SHA=$(echo "${2:-$(git rev-parse HEAD)}" | cut -c 1-7) && sed -i "/CurrentVersionNumber/s/\"$/-$SHA\"/" version.go
+RUN cd kubo && \
+    SHA=$(echo "${2:-$(git rev-parse HEAD)}" | cut -c 1-7) && \
+    sed -i "/CurrentVersionNumber/s/\"$/-$SHA\"/" version.go
 
 # Note: when updating the go minor version here, also update the go-channel in snap/snapcraft.yml
 FROM golang:1.19.1-buster as builder

--- a/container-init.d/000-ceramic.sh
+++ b/container-init.d/000-ceramic.sh
@@ -35,10 +35,11 @@ ipfs config Pubsub.SeenMessagesTTL 10m
 ipfs config --json Swarm.RelayClient.Enabled false
 
 BOOTSTRAP_PEERS='[
-  {"ID": "QmXALVsXZwPWTUbsT8G6VVzzgTJaAWRUD7FWL5f7d5ubAL", "Addrs": ["/dns4/go-ipfs-ceramic-private-mainnet-external.3boxlabs.com/tcp/4011/ws/p2p/QmXALVsXZwPWTUbsT8G6VVzzgTJaAWRUD7FWL5f7d5ubAL"]},
-  {"ID": "QmUvEKXuorR7YksrVgA7yKGbfjWHuCRisw2cH9iqRVM9P8", "Addrs": ["/dns4/go-ipfs-ceramic-private-cas-mainnet-external.3boxlabs.com/tcp/4011/ws/p2p/QmUvEKXuorR7YksrVgA7yKGbfjWHuCRisw2cH9iqRVM9P8"]},
-  {"ID": "QmUiF8Au7wjhAF9BYYMNQRW5KhY7o8fq4RUozzkWvHXQrZ", "Addrs": ["/dns4/go-ipfs-ceramic-elp-1-1-external.3boxlabs.com/tcp/4011/ws/p2p/QmUiF8Au7wjhAF9BYYMNQRW5KhY7o8fq4RUozzkWvHXQrZ"]},
-  {"ID": "QmRNw9ZimjSwujzS3euqSYxDW9EHDU5LB3NbLQ5vJ13hwJ", "Addrs": ["/dns4/go-ipfs-ceramic-elp-1-2-external.3boxlabs.com/tcp/4011/ws/p2p/QmRNw9ZimjSwujzS3euqSYxDW9EHDU5LB3NbLQ5vJ13hwJ"]},
-  {"ID": "QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd", "Addrs": ["/dns4/go-ipfs-ceramic-private-cas-clay-external.3boxlabs.com/tcp/4011/ws/p2p/QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd"]}
+  {"ID": "QmXALVsXZwPWTUbsT8G6VVzzgTJaAWRUD7FWL5f7d5ubAL",       "Addrs": ["/dns4/go-ipfs-ceramic-private-mainnet-external.3boxlabs.com/tcp/4011/ws/p2p/QmXALVsXZwPWTUbsT8G6VVzzgTJaAWRUD7FWL5f7d5ubAL"]},
+  {"ID": "QmUvEKXuorR7YksrVgA7yKGbfjWHuCRisw2cH9iqRVM9P8",       "Addrs": ["/dns4/go-ipfs-ceramic-private-cas-mainnet-external.3boxlabs.com/tcp/4011/ws/p2p/QmUvEKXuorR7YksrVgA7yKGbfjWHuCRisw2cH9iqRVM9P8"]},
+  {"ID": "QmUiF8Au7wjhAF9BYYMNQRW5KhY7o8fq4RUozzkWvHXQrZ",       "Addrs": ["/dns4/go-ipfs-ceramic-elp-1-1-external.3boxlabs.com/tcp/4011/ws/p2p/QmUiF8Au7wjhAF9BYYMNQRW5KhY7o8fq4RUozzkWvHXQrZ"]},
+  {"ID": "QmRNw9ZimjSwujzS3euqSYxDW9EHDU5LB3NbLQ5vJ13hwJ",       "Addrs": ["/dns4/go-ipfs-ceramic-elp-1-2-external.3boxlabs.com/tcp/4011/ws/p2p/QmRNw9ZimjSwujzS3euqSYxDW9EHDU5LB3NbLQ5vJ13hwJ"]},
+  {"ID": "QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd",       "Addrs": ["/dns4/go-ipfs-ceramic-private-cas-clay-external.3boxlabs.com/tcp/4011/ws/p2p/QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd"]},
+  {"ID": "12D3KooWDYD5hgsnvqtuTQsTsqwt37gFY6YdQ9qeJNTzLMKph1rF", "Addrs": ["/ip4/155.138.235.201/tcp/4001/p2p/12D3KooWDYD5hgsnvqtuTQsTsqwt37gFY6YdQ9qeJNTzLMKph1rF"]}
 ]'
 ipfs config --json Peering.Peers "${BOOTSTRAP_PEERS}"


### PR DESCRIPTION
The Dockerfile update will change the version string to something like this:
```
const CurrentVersionNumber = "ceramic-0.19.1-validator-1c3115f"
```
That way, if we need to, we can also differentiate various commits, independent of the Kubo version in our fork.