### PR TITLE
feat: optionally enable gateway port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,9 @@ EXPOSE $IPFS_API_PORT
 # Swarm Websockets; must be exposed publicly when the node is listening using the websocket transport (/ipX/.../tcp/8081/ws).
 ENV IPFS_SWARM_WS_PORT 8081
 EXPOSE $IPFS_SWARM_WS_PORT
+# Gateway; readonly gateway which can be exposed to the public
+ENV IPFS_GATEWAY_PORT 8080
+EXPOSE $IPFS_GATEWAY_PORT
 # Healthcheck Server; can be exposed to services under your control
 ENV IPFS_HEALTHCHECK_PORT 8011
 EXPOSE $IPFS_HEALTHCHECK_PORT

--- a/container-init.d/000-ceramic.sh
+++ b/container-init.d/000-ceramic.sh
@@ -27,8 +27,13 @@ fi
 ipfs repo migrate
 
 ipfs config Addresses.API "/ip4/0.0.0.0/tcp/$IPFS_API_PORT"
-# Explicitly disable the gateway
-ipfs config --json Addresses.Gateway '[]'
+# Explicitly set the gateway to an empty array to disable it by default
+ipfs config --json Addresses.Gateway "[]"
+if [[ $GATEWAY_ENABLED ]] ; then
+  echo "Enabling IPFS Gateway..."
+  echo $GATEWAY_ENABLED
+  ipfs config --json Addresses.Gateway "[\"/ip4/0.0.0.0/tcp/$IPFS_GATEWAY_PORT\"]"
+fi
 ipfs config --json Addresses.Swarm "[\"/ip4/0.0.0.0/tcp/$IPFS_SWARM_TCP_PORT\", \"/ip4/0.0.0.0/tcp/$IPFS_SWARM_WS_PORT/ws\"]"
 ipfs config --json Pubsub.Enabled true
 ipfs config Pubsub.SeenMessagesTTL 10m


### PR DESCRIPTION
# Ability to optionally enable Gateway

## Description

The motivation behind this is the fact that the IPFS node could be reused for other purposes as well by enabling the gateway. The gateway port can stay closed by default but with this PR, it gives developers the ability to enable the gateway by setting the environment variable `GATEWAY_ENABLED=true` when running in Docker. The motivation comes from our issue - running a single instance of the IPFS node on our server and using it for Ceramic as well as other purposes. The environment variable can be passed either with a `docker run` command e.g. `docker run -p 5001:5001 -p 8011:8011 -p 8080:8080 go-ipfs-daemon` or in `docker-compose.yml`, e.g.
```yml
version: '3'

services:
  ipfs:
    image: go-ipfs-daemon
    container_name: ipfs
    ports:
      - 5001:5001
      - 8011:8011
      - 8080:8080
```
## How Has This Been Tested?
Ran locally with barebones `docker run` command and with `docker compose up`.

## Definition of Done

Additionally, the documentation could also be updated to note this option.

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
